### PR TITLE
Add extra test to OSHelper to properly determine is Platform is MacOSX o...

### DIFF
--- a/PluginCore/API/OSHelper.cs
+++ b/PluginCore/API/OSHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace PluginCore
 {
@@ -20,10 +21,52 @@ namespace PluginCore
 					API = new MacAPI();
 					break;
 				case PlatformID.Unix:
-					API = new LinuxAPI();
+					if(IsRunningOnMac())
+					{
+						API = new MacAPI();
+					} else
+					{
+						API = new LinuxAPI();
+					}
 					break;
 				default: throw new Exception(Environment.OSVersion.ToString());
 			}
+		}
+
+		[DllImport("libc")]
+		static extern int uname(IntPtr buf);
+
+		// Mono returns PlatformID.Unix for MacOSX so we should test platform by other ways
+		// "Notice that as of Mono 2.2 the version returned on MacOS X is still 4 for legacy reasons, 
+		//  too much code was written between the time that the MacOSX value was introduced and the 
+		//  time that we wrote this text which has lead to a lot of user code in the wild to not cope with 
+		//  the newly introduced value."
+		// http://www.mono-project.com/docs/faq/technical/
+		public static bool IsRunningOnMac()
+		{
+			IntPtr buf = IntPtr.Zero;
+			try
+			{
+				buf = Marshal.AllocHGlobal(8192);
+				if(uname(buf) == 0)
+				{
+					string os = Marshal.PtrToStringAnsi(buf);
+					return os.Contains("Darwin");
+				}
+			}
+			catch
+			{
+				// don't do anything
+			}
+			finally
+			{
+				if(buf != IntPtr.Zero)
+				{
+					Marshal.FreeHGlobal(buf);
+				}
+			}
+
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
...r not
- we should do this because of legacy issues in Mono
- Mono returns PlatformID.Unix for MacOSX
- fixes #21
